### PR TITLE
Fix VS2022 and Python 3.10 build failure on Windows 

### DIFF
--- a/libpyclingo/pyclingo.cc
+++ b/libpyclingo/pyclingo.cc
@@ -116,7 +116,7 @@ struct ObjectProtocoll {
     Object call(char const *name, Args &&... args);
     template <class... Args>
     Object operator()(Args &&... args);
-    ssize_t size();
+    Py_ssize_t size();
     bool empty() { return size() == 0; }
     Object getItem(Reference o);
     Object getItem(char const *key);
@@ -232,7 +232,7 @@ Object ObjectProtocoll<T>::operator()(Args &&... args) {
     return PyObject_CallFunctionObjArgs(toPy_(), Reference(args).toPy()..., nullptr);
 }
 template <class T>
-ssize_t ObjectProtocoll<T>::size() {
+Py_ssize_t ObjectProtocoll<T>::size() {
     auto ret = PyObject_Size(toPy_());
     if (PyErr_Occurred()) { throw PyException(); }
     return ret;

--- a/libpyclingo/pyclingo.cc
+++ b/libpyclingo/pyclingo.cc
@@ -25,6 +25,13 @@
 // NOTE: the python header has a linker pragma to link with python_d.lib
 //       when _DEBUG is set which is not part of official python releases
 #if defined(_MSC_VER) && defined(_DEBUG) && !defined(CLINGO_UNDEF__DEBUG)
+// Workaround for a VS 2022 issue.
+// NOTE: This workaround knowingly violates the Python.h include order requirement:
+// https://docs.python.org/3/c-api/intro.html#include-files
+#   include <yvals.h>
+# if _MSVC_STL_VERSION >= 143
+#   include <crtdefs.h>
+# endif
 #undef _DEBUG
 #include <Python.h>
 #define _DEBUG


### PR DESCRIPTION
Using `#undef _DEBUG` in VS2022 leads to ` _invalid_parameter` failures. (https://github.com/microsoft/STL/issues/2335) This can be fixed by
- Including `<yvals.h>` and `<crtdefs.h>` before. (https://github.com/pybind/pybind11/pull/3497), or
- `#define _STL_CRT_SECURE_INVALID_PARAMETER(expr) _CRT_SECURE_INVALID_PARAMETER(expr)
`

Windows doesn't have `ssize_t`. We can either 
- Replace `ssize_t` with `Py_ssize_t` (https://github.com/jpype-project/jpype/pull/1011), or
- Alias `ssize_t` to `SSIZE_t`. 
  ```c++
  #include <BaseTsd.h>
  typedef SSIZE_T ssize_t;
  ```